### PR TITLE
Updated the "Live Demo" link for the "Universal News Scraper" project…

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
                             </div>
                             
                             <div class="flex gap-4">
-                                <a href="https://news-scraper-vercel-4zu8nqnxi-prestigecorp4s-projects.vercel.app" 
+                                <a href="https://news.prestigecorp.au"
                                    target="_blank" 
                                    class="bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded-lg font-semibold transition duration-300 flex items-center">
                                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
… in `index.html`.

The link was changed from the Vercel deployment URL to the new custom domain `news.prestigecorp.au`.